### PR TITLE
Move from setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["setuptools", "versioneer[toml]"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "zenAPIClient"
+dynamic = ["version"]
+authors = [
+  {name = "Dan Smalley", email="zenapiclient@smalley.link"}
+]
+description = "Zenoss API client module"
+readme = "README.md"
+license = {file = "LICENSE.md"}
+keywords = ["zenoss", "monitoring", "api"]
+classifiers=[
+          "Intended Audience :: System Administrators",
+          "License :: OSI Approved :: Apache Software License",
+          "Natural Language :: English",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.12",
+          "Topic :: System :: Monitoring",
+      ]
+dependencies = [
+  "python-dateutil>=2.6.1",
+  "requests>=2.18.1",
+]
+requires-python = ">=3.6"
+
+[project.optional-dependencies]
+test = [
+  "pytest>=3.2.3",
+  "pytest-responses>=0.4.0",
+  "versioneer",
+]
+
+[tool.versioneer]
+VCS = "git"
+style = "pep440"
+versionfile_source = "src/zenossapi/_version.py"
+versionfile_build = "zenossapi/_version.py"
+tag_prefix = "v"
+parentdir_prefix = "zenAPIClient"
+
+[tool.coverage.run]
+omit = [
+    "_version.py",
+    ]
+
+[project.urls]
+Homepage = "https://github.com/dan-smalley/zenAPIClient"
+Documentation = "https://zenapiclient.readthedocs.io"
+Repository = "https://github.com/dan-smalley/zenAPIClient.git"

--- a/setup.py
+++ b/setup.py
@@ -1,58 +1,10 @@
-import os
-from setuptools import find_packages, setup
-import sys
+#!/usr/bin/env python
 
-sys.path.insert(0, os.path.join(os.path.abspath(os.path.curdir), 'src'))
-from zenossapi import __version__, __release__
+import setuptools
+import versioneer
 
-name = 'ZenossAPIClient'
-
-setup(name=name,
-      version=__release__,
-      description='Zenoss API client module',
-      long_description="""
-Python module for interacting with the Zenoss API an an object-oriented way.
-The philosophy here is to use objects to work with everything in the Zenoss 
-API, and to try to normalize the various calls to the different routers.
-Thus `get` methods will always return an object, `list` methods will return 
-data. All methods to add or create start with `add`, all remove or delete 
-start with `delete`. As much as possible the methods try to hide the 
-idiosyncrasies of the JSON API, and to do the work for you, for example 
-by letting you use a device name instead of having to provide the full 
-device UID for every call.
-""",
-      url='https://github.com/Zuora-TechOps/ZenossAPIClient',
-      author='Mark Troyer',
-      author_email='disco@zuora.com',
-      license='Apache',
-      classifiers=[
-          'Intended Audience :: System Administrators',
-          'License :: OSI Approved :: Apache Software License',
-          'Natural Language :: English',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.7',
-          'Topic :: System :: Monitoring',
-      ],
-      keywords='Zenoss monitoring api',
-      packages=find_packages(where='src'),
-      package_dir={'': 'src'},
-      zip_safe=False,
-      tests_require=[
-          'pytest>=3.2.3',
-          'pytest-responses>=0.3.0',
-      ],
-      install_requires=[
-          'python-dateutil>=2.6.1',
-          'requests>=2.18.1',
-      ],
-      command_options={
-          'build_sphinx': {
-              'project': ('setup.py', name),
-              'version': ('setup.py', __version__),
-              'release': ('setup.py', __release__),
-              'source_dir': ('setup.py', 'docs'),
-              'build_dir': ('setup.py', 'docs/_build'),
-              'config_dir': ('setup.py', 'docs'),
-          }
-      }
-      )
+if __name__ == "__main__":
+    setuptools.setup(
+        version=versioneer.get_version(),
+        cmdclass=versioneer.get_cmdclass(),
+    )


### PR DESCRIPTION
- Moved from setup.py as the primary config file to the more modern pyproject.toml.
- Maintained setup.py shim to allow for automatic versioning and backward compatibility.
- Increased minimum python version to 3.6
  - Backwards compatibility for 2.7 was not removed but is no longer maintained/tested.