### PR TITLE
Prod deployment

### DIFF
--- a/.github/workflows/PyPI_package_upload.yaml
+++ b/.github/workflows/PyPI_package_upload.yaml
@@ -10,14 +10,20 @@
 name: PyPI Package Upload
 
 on:
-  release:
-    types: [published]
+  workflow_call:
+    inputs:
+      workflow-environment:
+        required: true
+        type: string
+      pypi-url:
+        required: true
+        type: string
 
 jobs:
-  testpypi_upload:
+  pypi_upload:
     runs-on: ubuntu-latest
     environment:
-      name: Dev
+      name: ${{ inputs.workflow-environment }}
     permissions:
       id-token: write
     steps:
@@ -35,4 +41,4 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
+          repository-url: ${{ inputs.pypi-url }}

--- a/.github/workflows/deploy_release_to_PyPI.yaml
+++ b/.github/workflows/deploy_release_to_PyPI.yaml
@@ -1,0 +1,28 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Deploy Release to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test_pypi_upload:
+    uses: dan-smalley/zenAPIClient/.github/workflows/PyPI_package_upload.yaml@main
+    with:
+      workflow-environment: Dev
+      pypi-url: https://test.pypi.org/legacy/
+
+  prod_pypi_upload:
+    needs: test_pypi_upload
+    uses: dan-smalley/zenAPIClient/.github/workflows/PyPI_package_upload.yaml@main
+    with:
+      workflow-environment: Prod
+      pypi-url: https://pypi.org/legacy/

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![Tests badge](https://github.com/dan-smalley/zenAPIClient/actions/workflows/test_and_lint.yml/badge.svg) 
 [![Documentation Status](https://readthedocs.org/projects/zenapiclient/badge/?version=latest)](https://zenapiclient.readthedocs.io/en/latest/?badge=latest) 
 [![Coverage Status](https://dan-smalley.github.io/zenAPIClient/coveragecoverage-badge.svg?dummy=8484744)](https://dan-smalley.github.io/zenAPIClient/index.html)
-![PyPI - Version](https://img.shields.io/pypi/v/zenAPIClient?pypiBaseUrl=https%3A%2F%2Ftest.pypi.org&logo=pypi&label=TestPyPI) 
+![PyPI - Version](https://img.shields.io/pypi/v/zenAPIClient?logo=pypi&label=PyPI)
 ![GitHub Release](https://img.shields.io/github/v/release/dan-smalley/zenAPIClient?include_prereleases&logo=github&label=Release)
-
+![TestPyPI - Version](https://img.shields.io/pypi/v/zenAPIClient?pypiBaseUrl=https%3A%2F%2Ftest.pypi.org&logo=pypi&label=TestPyPI) 
 
 
 


### PR DESCRIPTION
- Add production tags to README.md
- Convert publish workflow to be reusable 
- Create new  release deployment workflow to call now reusable workflow