### PR TITLE
drs_update_props_router

### DIFF
--- a/src/zenossapi/routers/cmdb.py
+++ b/src/zenossapi/routers/cmdb.py
@@ -81,7 +81,7 @@ class CmdbRouter(ZenossRouter):
             'next_full_run': active_config['nextFullRun'],
             'last_run_started': active_config['lastRunStarted'],
             'last_run_finished': active_config['lastRunFinished'],
-            'last_successful_run_finished': ['lastRunSuccessFinished']
+            'last_successful_run_finished': active_config['lastRunSuccessFinished']
         }
 
         return stats

--- a/src/zenossapi/routers/device.py
+++ b/src/zenossapi/routers/device.py
@@ -893,6 +893,28 @@ class DeviceRouter(ZenossRouter):
 
         return response_data['success']
 
+    def set_info_by_uid(self, device_uid, property, value):
+        """
+        Set Attributes on a device or device organizer
+
+        Arguments:
+            device_uid (str): The uid of the device to comment on
+            property (str): Name of the attribute to set
+            value (str): Value of the attribute to set
+
+        Returns:
+            str: Response message
+        """
+
+        response_data = self._router_request(
+            self._make_request_data(
+                'setInfo',
+                {'uid': device_uid, property: value}
+            )
+        )
+
+        return response_data['success']
+
 
 class ZenossDeviceClass(DeviceRouter):
     """
@@ -1280,7 +1302,7 @@ class ZenossDeviceClass(DeviceRouter):
             bool:
         """
         pr = PropertiesRouter(self.api_url, self.api_headers, self.ssl_verify)
-        return pr.set_property_value(self.uid, zproperty, value=value)
+        return pr.set_property_value(self.uid, id=zproperty, value=value)
 
     def delete_property(self, zproperty):
         """
@@ -1653,7 +1675,7 @@ class ZenossDevice(DeviceRouter):
             list(ZenossTemplate):
         """
         ut_list = self.list_unbound_templates()
-        find_path = re.compile('\((\/.*)\)')
+        find_path = re.compile('[(]([/].*)[)]')
         templates = []
         tr = TemplateRouter(self.api_url, self.api_headers, self.ssl_verify)
         for t in ut_list:
@@ -1708,7 +1730,7 @@ class ZenossDevice(DeviceRouter):
             list(ZenosTemplate):
         """
         bt_list = self.list_bound_templates()
-        find_path = re.compile('\((\/.*)\)')
+        find_path = re.compile('[(]([/].*)[)]')
         templates = []
         tr = TemplateRouter(self.api_url, self.api_headers, self.ssl_verify)
         for t in bt_list:
@@ -1979,6 +2001,21 @@ class ZenossDevice(DeviceRouter):
             self.comments = f'{self.comments}\n{comment}'
         else:
             self.comments = comment
+        return message
+
+    def set_info(self, property, value):
+        """
+        Set attribute of a device. DOES NOT update zProps or cProps
+
+        Arguments:
+            property (str): Name of property to set
+            value (str): Value to set property to
+
+        Returns:
+            str: Reponse message
+        """
+
+        message = self.set_info_by_uid(self.uid, property, value)
         return message
     
 

--- a/src/zenossapi/routers/properties.py
+++ b/src/zenossapi/routers/properties.py
@@ -297,7 +297,7 @@ class PropertiesRouter(ZenossRouter):
             prop_data['data'][0]
         )
 
-    def set_property_value(self, uid, zproperty, value=None):
+    def set_property_value(self, uid, id, value=None):
         """
         Sets (or updates) the local value of a property
 
@@ -309,16 +309,16 @@ class PropertiesRouter(ZenossRouter):
         """
         property_data = self._router_request(
             self._make_request_data(
-                'setZenProperty',
+                'update',
                 dict(
                     uid=uid,
-                    zProperty=zproperty,
+                    id=id,
                     value=value,
                 )
             )
         )
 
-        return property_data['data']
+        return True
 
     def delete_property(self, uid, zproperty):
         """
@@ -357,8 +357,14 @@ class ZenossProperty(PropertiesRouter):
         self.description = property_data['description']
         self.islocal = property_data['islocal']
         self.label = property_data['label']
-        self.value = property_data['value']
-        self.valueAsString = property_data['valueAsString']
+        if 'value' not in property_data:
+            self.value = 'REDACTED'
+        else:
+            self.value = property_data['value']
+        if 'valueAsString' not in property_data:
+            self.valueAsString = 'REDACTED'
+        else:
+            self.valueAsString = property_data['valueAsString']
         self.path = 'Devices{0}'.format(property_data['path'])
         self.type = property_data['type']
         self.options = []
@@ -379,8 +385,8 @@ class ZenossProperty(PropertiesRouter):
 
         property_data = self.set_property_value(self.path, self.id, value=value)
 
-        self.value = property_data['value']
-        self.valueAsString = property_data['valueAsString']
+        self.value = value
+        self.valueAsString = str(value)
         self.islocal = '1'
 
         return True
@@ -412,8 +418,14 @@ class ZenossCustomProperty(PropertiesRouter):
         self.id = property_data['id']
         self.islocal = property_data['islocal']
         self.label = property_data['label']
-        self.value = property_data['value']
-        self.valueAsString = property_data['valueAsString']
+        if 'value' not in property_data:
+            self.value = 'REDACTED'
+        else:
+            self.value = property_data['value']
+        if 'valueAsString' not in property_data:
+            self.valueAsString = 'REDACTED'
+        else:
+            self.valueAsString = property_data['valueAsString']
         self.path = 'Devices{0}'.format(property_data['path'])
         self.type = property_data['type']
         self.options = property_data['options']
@@ -434,8 +446,8 @@ class ZenossCustomProperty(PropertiesRouter):
 
         property_data = self.set_property_value(self.path, self.id, value=value)
 
-        self.value = property_data['value']
-        self.valueAsString = property_data['valueAsString']
+        self.value = value
+        self.valueAsString = str(value)
         self.islocal = '1'
 
         return True

--- a/tests/routers/properties_resp.py
+++ b/tests/routers/properties_resp.py
@@ -245,3 +245,15 @@ set_custom_prop = {
     "type": "rpc",
     "method": "setZenProperty"
 }
+
+update = {
+    "uuid": "62bc1c3b-f7f3-41b1-89af-5b0720d089cc",
+    "action": "PropertiesRouter",
+    "result": {
+        "msg": "Property updated.",
+        "success": True
+    },
+    "tid": 1,
+    "type": "rpc",
+    "method": "update"
+}

--- a/tests/routers/resp_json.py
+++ b/tests/routers/resp_json.py
@@ -1379,3 +1379,15 @@ delete_c = {
     "type": "rpc",
     "method": "deleteComponents"
 }
+
+update = {
+    "uuid": "62bc1c3b-f7f3-41b1-89af-5b0720d089cc",
+    "action": "PropertiesRouter",
+    "result": {
+        "msg": "Property updated.",
+        "success": True
+    },
+    "tid": 1,
+    "type": "rpc",
+    "method": "update"
+}

--- a/tests/routers/test_device_router.py
+++ b/tests/routers/test_device_router.py
@@ -91,7 +91,7 @@ def request_callback(request):
 
     def getUnboundTemplates(rdata):
         return resp_json.ub_templates
-    
+
     def getBoundTemplates(rdata):
         return resp_json.bound_templates
 
@@ -155,6 +155,18 @@ def request_callback(request):
 
     def deleteZenProperty(rdata):
         return properties_resp.delete_prop
+
+    def update(rdata):
+        return {
+            "uuid": "ba2f41f8-3c48-40a6-ab45-3c5e84252c3c",
+            "action": "PropertiesRouter",
+            "result": {
+                "success": True
+            },
+            "tid": 1,
+            "type": "rpc",
+            "method": "update"
+        }
 
     if rdata['method'] in ['setBoundTemplates', 'bindOrUnbindTemplate',
                            'resetBoundTemplates', 'renameDevice',
@@ -451,7 +463,7 @@ class TestDeviceRouter(object):
         dr = DeviceRouter(url, headers, True)
         dc = dr.get_device_class('Server/TEST')
         prop = dc.set_property('zWinTrustedRealm', value='Westeros')
-        assert prop['value'] == "Westeros"
+        assert prop is True
 
     def test_device_router_zenossdeviceclass_delete_property(self, responses):
         responses.add_callback(
@@ -622,7 +634,7 @@ class TestDeviceRouter(object):
         d = dc.get_device('test.example.com')
         resp = d.list_bound_templates()
         assert resp[0]['name'] == "Device"
-        
+
     def test_device_router_zenossdevice_get_bound_templates(self, responses):
         responses.assert_all_requests_are_fired = False
         responses.add_callback(
@@ -969,7 +981,7 @@ class TestDeviceRouter(object):
         dc = dr.get_device_class('Server/TEST')
         d = dc.get_device('test.example.com')
         prop = d.set_property('zWinTrustedRealm', value='Westeros')
-        assert prop['value'] == "Westeros"
+        assert prop is True
 
     def test_device_router_zenossdevice_delete_property(self, responses):
         responses.add_callback(

--- a/tests/routers/test_properties_router.py
+++ b/tests/routers/test_properties_router.py
@@ -49,6 +49,18 @@ def request_callback(request):
     def deleteZenProperty(rdata):
         return properties_resp.delete_prop
 
+    def update(rdata):
+        return {
+            "uuid": "ba2f41f8-3c48-40a6-ab45-3c5e84252c3c",
+            "action": "PropertiesRouter",
+            "result": {
+                "success": True
+            },
+            "tid": 1,
+            "type": "rpc",
+            "method": "update"
+        }
+
     method = locals()[rdata['method']]
     resp_body = method(rdata['data'][0])
 
@@ -150,7 +162,7 @@ class TestPropertiesRouter(object):
 
         pr = PropertiesRouter(url, headers, True)
         prop = pr.set_property_value('test.example.com', 'zWinTrustedRealm', value='Westeros')
-        assert prop['value'] == "Westeros"
+        assert prop is True
 
     def test_properties_router_zenossproperty_set_value(self, responses):
         responses_callback(responses)


### PR DESCRIPTION
# Property Management Enhancements and Bug Fixes

## Overview
This Pull Request includes improvements to property handling methods and fixes a bug in the CMDB router. The changes enhance the robustness of property management and provide additional methods for device property management.

## Changes

### 1. Bug Fix in CMDB Router
- Fixed an incorrect key reference in the `get_stats` method of the `CmdbRouter` class
- Corrected `'lastRunSuccessFinished'` key to fetch from `active_config` instead of a static list
- This ensures that the statistics are correctly retrieved and reported

### 2. Property Handling Refactoring
- Updated `set_property_value` method to use `id` parameter instead of `zproperty` for consistency
- Added robust handling for missing fields (`value` and `valueAsString`) with a default of `REDACTED`
- Modified the return value of `set_property_value` to return `True` instead of a dictionary for simplicity and consistency
- Updated related test cases to align with the new return value

### 3. New Device Property Management Methods
- Added `set_info_by_uid` method to the `DeviceRouter` class for setting attributes on devices or device organizers
- Added `set_info` method to the `ZenossDevice` class as a convenient wrapper for `set_info_by_uid`
- These methods provide a clear distinction between setting device attributes and configuration properties

### 4. Code Readability Improvements
- Updated regex patterns in template methods for improved readability

## Impact
- Improved error handling for properties with missing fields
- More consistent API for property management
- Fixed a bug that could cause incorrect statistics reporting
- Enhanced device property management capabilities
- Better code readability

## Testing
All tests have been updated to align with the new implementation and pass successfully.